### PR TITLE
README tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides abstract models to help Django developers quickly implemen
 
 Install `django-dynamic-model` from PyPi with:
 
-```python
+```
 pip install django-dynamic-model
 ```
 


### PR DESCRIPTION
`pip install` is a shell command, not Python.