### PR TITLE
fix on_delete (de)serialization to DB

### DIFF
--- a/dynamic_models/compat.py
+++ b/dynamic_models/compat.py
@@ -1,0 +1,4 @@
+try:
+    from django.db.models import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField

--- a/dynamic_models/migrations/0003_add_classname_remove_datatype.py
+++ b/dynamic_models/migrations/0003_add_classname_remove_datatype.py
@@ -1,5 +1,5 @@
-import django.contrib.postgres.fields.jsonb
 from django.db import migrations, models
+from dynamic_models.models import FieldKwargsJSON
 
 
 def set_defaults(apps, schema_editor):
@@ -37,7 +37,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="fieldschema",
             name="kwargs",
-            field=django.contrib.postgres.fields.jsonb.JSONField(null=True),
+            field=FieldKwargsJSON(null=True),
         ),
         migrations.RunPython(set_defaults),
         migrations.AlterField(
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="fieldschema",
             name="kwargs",
-            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict, null=False),
+            field=FieldKwargsJSON(default=dict, null=False),
         ),
         migrations.RemoveField(
             model_name="fieldschema",

--- a/dynamic_models/models.py
+++ b/dynamic_models/models.py
@@ -1,6 +1,6 @@
-from django.core.exceptions import FieldDoesNotExist
+from typing import get_args
+from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models
-from django.contrib.postgres.fields import JSONField
 from django.utils.text import slugify
 
 from dynamic_models import config, cache
@@ -65,14 +65,52 @@ class ModelSchema(models.Model):
         return self._factory.get_model()
 
 
+class FieldKwargsJSON(models.JSONField):
+    description = "A field that handles storing models.Field kwargs as JSON"
+
+    def to_python(self, value):
+        raw_value = super().to_python(value)
+        try:
+            return self._convert_on_delete_to_function(raw_value)
+        except AttributeError as err:
+            raise ValidationError("Invalid value for 'on_delete'") from err
+
+    def from_db_value(self, value, expression, connection):
+        db_value = super().from_db_value(value, expression, connection)
+        return self._convert_on_delete_to_function(db_value)
+
+    def get_prep_value(self, value):
+        prep_value = self._convert_on_delete_to_string(value)
+        return super().get_prep_value(prep_value)
+
+    def _convert_on_delete_to_function(self, raw_value):
+        if raw_value is None or "on_delete" not in raw_value:
+            return raw_value
+
+        raw_on_delete = raw_value["on_delete"]
+        if isinstance(raw_on_delete, str):
+            raw_value["on_delete"] = getattr(models, raw_on_delete)
+
+        return raw_value
+
+    def _convert_on_delete_to_string(self, raw_value):
+        if raw_value is None or "on_delete" not in raw_value:
+            return raw_value
+
+        raw_on_delete = raw_value["on_delete"]
+        if callable(raw_on_delete):
+            raw_value["on_delete"] = raw_on_delete.__name__
+
+        return raw_value
+
+
 class FieldSchema(models.Model):
     _PROHIBITED_NAMES = ("__module__", "_declared")
-    _MAX_LENGTH_DATA_TYPES = ("character",)
 
     name = models.CharField(max_length=63)
     model_schema = models.ForeignKey(ModelSchema, on_delete=models.CASCADE, related_name="fields")
     class_name = models.TextField()
-    kwargs = JSONField(default=dict)
+    kwargs = FieldKwargsJSON(default=dict)
 
     class Meta:
         unique_together = (("name", "model_schema"),)
@@ -117,10 +155,6 @@ class FieldSchema(models.Model):
         # TODO: return prohbited names based on backend
         return cls._PROHIBITED_NAMES
 
-    @classmethod
-    def get_data_types(cls):
-        return FieldFactory.get_data_types()
-
     @property
     def db_column(self):
         return slugify(self.name).replace("-", "_")
@@ -137,7 +171,7 @@ class FieldSchema(models.Model):
         cache.update_last_modified(self.model_schema.initial_model_name)
 
     def get_options(self):
-        return {**self.kwargs}
+        return self.kwargs.copy()
 
     def _get_model_with_field(self):
         model = self.model_schema.as_model()

--- a/dynamic_models/models.py
+++ b/dynamic_models/models.py
@@ -1,10 +1,9 @@
-from typing import get_args
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models
 from django.utils.text import slugify
 
 from dynamic_models import config, cache
-from dynamic_models.factory import ModelFactory, FieldFactory
+from dynamic_models.factory import ModelFactory
 from dynamic_models.exceptions import NullFieldChangedError, InvalidFieldNameError
 from dynamic_models.schema import ModelSchemaEditor, FieldSchemaEditor
 from dynamic_models.utils import ModelRegistry

--- a/dynamic_models/schema.py
+++ b/dynamic_models/schema.py
@@ -19,7 +19,7 @@ class ModelSchemaEditor:
             with connection.schema_editor() as editor:
                 editor.create_model(new_model)
         except ProgrammingError as err:
-            # TODO: I couldn't figure out why sometimes despite the 
+            # TODO: I couldn't figure out why sometimes despite the
             # fact that the model exists, the initial_model is None and
             # therefore this method will be called which leads to this
             # error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,4 +52,8 @@ def another_model_schema(db):
 
 @pytest.fixture
 def field_schema(db, model_schema):
-    return FieldSchema.objects.create(name="field", class_name="django.db.models.IntegerField", model_schema=model_schema)
+    return FieldSchema.objects.create(
+        name="field",
+        class_name="django.db.models.IntegerField",
+        model_schema=model_schema
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -154,8 +154,14 @@ class TestDynamicModels:
         related_instance = related_model.objects.create()
         model_instance = model.objects.create(related=related_instance)
 
+        # related objects should be accessible through related managers
         assert model_instance.related == related_instance
         assert related_instance.parent_objects.first() == model_instance
+
+        # CASCADE should work correctly
+        related_instance.delete()
+        with pytest.raises(model.DoesNotExist):
+            model.objects.get(pk=model_instance.pk)
 
     def test_model_with_many_to_many(self, model_schema, another_model_schema):
         FieldSchema.objects.create(
@@ -171,5 +177,6 @@ class TestDynamicModels:
         related_model_instance = related_model.objects.create()
         model_instance.many_related.add(related_model_instance)
 
+        # related objects should be accessible through related managers
         assert model_instance.many_related.first() == related_model_instance
         assert related_model_instance.related_objects.first() == model_instance

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.0
-envlist = py{36,37,38}-django31-postgres
+envlist = py{36,37,38}-django{21,22,30,31}-postgres
 
 [testenv]
 requires = setuptools
@@ -11,6 +11,9 @@ platform =
     windows: win32
 
 deps =
+    django21: Django>=2.1, <2.2
+    django22: Django>=2.2, <2.3
+    django30: Django>=3.0, <3.1
     django31: Django>=3.1
     postgres: psycopg2-binary
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.0
-envlist = py{36,37,38}-django{21,22,30,31}-postgres
+envlist = py{36,37,38}-django31-postgres
 
 [testenv]
 requires = setuptools
@@ -11,9 +11,6 @@ platform =
     windows: win32
 
 deps =
-    django21: Django>=2.1, <2.2
-    django22: Django>=2.2, <2.3
-    django30: Django>=3.0, <3.1
     django31: Django>=3.1
     postgres: psycopg2-binary
     pytest


### PR DESCRIPTION
cc @adavoudi 

~~I had to either drop support for earlier Django versions, or implement a fairly heavy compatibility layer. For some reason `django.contrib.postgres.fields.JSONField` doesn't implement `from_db_value`.~~

Figured it out.