### PR TITLE
Fix style

### DIFF
--- a/dynamic_models/compat.py
+++ b/dynamic_models/compat.py
@@ -1,4 +1,4 @@
 try:
     from django.db.models import JSONField
 except ImportError:
-    from django.contrib.postgres.fields import JSONField
+    from django.contrib.postgres.fields import JSONField  # noqa

--- a/dynamic_models/models.py
+++ b/dynamic_models/models.py
@@ -1,5 +1,3 @@
-import json
-
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models
 from django.utils.text import slugify

--- a/dynamic_models/schema.py
+++ b/dynamic_models/schema.py
@@ -18,7 +18,7 @@ class ModelSchemaEditor:
         try:
             with connection.schema_editor() as editor:
                 editor.create_model(new_model)
-        except ProgrammingError as err:
+        except ProgrammingError:
             # TODO: I couldn't figure out why sometimes despite the
             # fact that the model exists, the initial_model is None and
             # therefore this method will be called which leads to this

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,7 +84,9 @@ class TestFieldSchema:
         prohibited_name = "__module__"
         with pytest.raises(InvalidFieldNameError):
             FieldSchema.objects.create(
-                name=prohibited_name, class_name="django.db.models.IntegerField", model_schema=model_schema
+                name=prohibited_name,
+                class_name="django.db.models.IntegerField",
+                model_schema=model_schema
             )
 
     def test_cannot_change_null_to_not_null(self, model_schema):


### PR DESCRIPTION
I've fixed those warnings from flake8:

```
django-dynamic-models % flake8 dynamic_models
dynamic_models/compat.py:4:5: F401 'django.contrib.postgres.fields.JSONField' imported but unused
dynamic_models/models.py:1:1: F401 'json' imported but unused
dynamic_models/schema.py:22:9: F841 local variable 'err' is assigned to but never used
django-dynamic-models % flake8 tests
tests/test_models.py:87:101: E501 line too long (107 > 100 characters)
```